### PR TITLE
Add ollama feature to devcontainer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
           - deno
           - latex
           - pre-commit
+          - ollama
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is structured to support the development of Dev Container featur
 - **Deno**:  [Deno](https://deno.com/) Javascript runtime written in rust
 - **LaTeX**: [TeX Live](https://www.tug.org/texlive/) installation with both latex and tlmgr runtimes, integrated with a VSCode extension for enhanced functionality.
 - **pre-commit**: [pre-commit](https://pre-commit.com/) framework for managing and maintaining multi-language pre-commit hooks in a single repository.
+- **ollama**: [ollama](https://ollama.ai/) Run AI models locally with ollama's CLI.
 
 ## Development and Testing
 

--- a/src/ollama/devcontainer-feature.json
+++ b/src/ollama/devcontainer-feature.json
@@ -1,0 +1,23 @@
+{
+    "name": "ollama",
+    "id": "ollama",
+    "version": "1.0.0",
+    "description": "Installs ollama",
+    "documentationURL": "https://github.com/prulloac/devcontainer-features/tree/main/src/ollama",
+    "options": {
+        "serve": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to serve ollama"
+        },
+        "pull": {
+            "type":"string",
+            "default": "",
+            "description": "comma separated list of models to pull"
+        }
+    },
+    "entrypoint": "ollama serve",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/src/ollama/install.sh
+++ b/src/ollama/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -i
+
+set -e
+
+PULL=${PULL:-""}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+	if ! dpkg -s "$@" >/dev/null 2>&1; then
+		if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+			echo "Running apt-get update..."
+			apt-get update -y
+		fi
+		apt-get -y install --no-install-recommends "$@"
+	fi
+}
+
+# make sure we have curl
+check_packages ca-certificates curl
+
+curl https://ollama.ai/install.sh | sh
+
+# if PULL is not empty and not equal to "none", also ollama is serving, then pull the models
+if [ "$PULL" != "none" ] && [ "$PULL" != "" ]; then
+    # split PULL variable into array using comma as delimiter and then pass to ollama pull
+    ollama serve &
+    sleep 3
+    echo $PULL | tr ',' '\n' | xargs -I % sh -c "ollama pull %"
+fi
+
+echo 'Done!'

--- a/test/ollama/scenarios.json
+++ b/test/ollama/scenarios.json
@@ -1,0 +1,12 @@
+{
+    "serve_and_pull": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "ollama": {
+                "serve": true,
+                "pull": "phi"
+            }
+        },
+        "remoteUser": "vscode"
+    }
+}

--- a/test/ollama/serve_and_pull.sh
+++ b/test/ollama/serve_and_pull.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'color' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "color": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in the
+# Feature's 'devcontainer-feature.json'.
+# For the 'color' feature, that means the default favorite color is 'red'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+# 
+# This test can be run with the following command:
+#
+#    devcontainer features test    \ 
+#               --features color   \
+#               --remote-user root \
+#               --skip-scenarios   \
+#               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#               /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+check "validate ollama installation" ollama --version | grep '1'
+check "validate if phi mdel is listed locally" ollama list | grep 'phi'
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/ollama/test.sh
+++ b/test/ollama/test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'color' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "color": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in the
+# Feature's 'devcontainer-feature.json'.
+# For the 'color' feature, that means the default favorite color is 'red'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+# 
+# This test can be run with the following command:
+#
+#    devcontainer features test    \ 
+#               --features color   \
+#               --remote-user root \
+#               --skip-scenarios   \
+#               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#               /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+check "validate ollama installation" ollama --version | grep '1'
+check "validate if ollama process is running" ollama list
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
This pull request adds the ollama feature to the devcontainer. The ollama feature allows running AI models locally with ollama's CLI. It includes the necessary files and configurations to install and serve ollama, as well as an example test script to validate the installation and functionality.