### PR TITLE
Remove serve option from devcontainer-feature.json

### DIFF
--- a/src/ollama/devcontainer-feature.json
+++ b/src/ollama/devcontainer-feature.json
@@ -5,11 +5,6 @@
     "description": "Installs ollama",
     "documentationURL": "https://github.com/prulloac/devcontainer-features/tree/main/src/ollama",
     "options": {
-        "serve": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether to serve ollama"
-        },
         "pull": {
             "type":"string",
             "default": "",


### PR DESCRIPTION
This pull request removes the "serve" option from the devcontainer-feature.json file. The option was no longer needed and has been removed to simplify the configuration.