### PR TITLE
[Latex] Allow passing custom mirror URLs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
           - gitlint
           - ollama
           - pre-commit
+          - latex
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -48,6 +49,7 @@ jobs:
           - deno
           - gitlint
           - pre-commit
+          - latex
     steps:
       - uses: actions/checkout@v3
 

--- a/src/latex/devcontainer-feature.json
+++ b/src/latex/devcontainer-feature.json
@@ -21,6 +21,15 @@
             "type": "string",
             "default": "",
             "description": "Comma separated list of packages to install with tlmgr. See https://www.tug.org/texlive/doc/tlmgr.html#installing-packages for more information."
+        },
+        "mirror": {
+            "type": "string",
+            "default": "https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz",
+            "description": "Provide a custom mirror to use for the installation of Tex Live. Omit option to automatically select the mirror closest to you.",
+            "proposals": [
+                "https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz",
+                "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
+            ]
         }
     },
     "customizations": {

--- a/src/latex/devcontainer-feature.json
+++ b/src/latex/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "LaTeX Workshop",
     "id": "latex",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Installs Tex Live latex compiler with tlmgr package manager, alongside LaTeX Workshop extension",
     "documentationURL": "https://github.com/prulloac/devcontainer-features/tree/main/src/latex",
     "options": {

--- a/src/latex/install.sh
+++ b/src/latex/install.sh
@@ -4,6 +4,7 @@ set -e
 
 SCHEME=${SCHEME:-"basic"}
 PACKAGES=${PACKAGES:-""}
+MIRROR=${MIRROR:-"https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"}
 
 check_packages() {
 	if ! dpkg -s "$@" >/dev/null 2>&1; then
@@ -15,11 +16,10 @@ check_packages() {
 	fi
 }
 
-
 check_packages ca-certificates perl wget perl-modules libfontconfig1 fontconfig
 
 cd /tmp # working directory of your choice
-wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz # or curl instead of wget
+wget "$MIRROR" # or curl instead of wget
 zcat < install-tl-unx.tar.gz | tar xf -
 cd $(ls -d */ | grep install-tl-)
 perl ./install-tl --no-interaction --scheme=$SCHEME

--- a/test/latex/custom_mirror.sh
+++ b/test/latex/custom_mirror.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Expected to behave the same as the minimal_texlive test
+./minimal_texlive.sh

--- a/test/latex/scenarios.json
+++ b/test/latex/scenarios.json
@@ -21,6 +21,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "latex": {
+                "scheme": "minimal",
                 "mirror": "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
             }
         },

--- a/test/latex/scenarios.json
+++ b/test/latex/scenarios.json
@@ -16,5 +16,14 @@
             }
         },
         "remoteUser": "vscode"
+    },
+    "custom_mirror": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "latex": {
+                "mirror": "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
+            }
+        },
+        "remoteUser": "vscode"
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
<!-- Add a brief description of the pr -->

Today I discovered your awesome Latex Feature on the [Features index](https://containers.dev/features), but it failed to install in my (US West-based) codespace with the following error:

```
302 Found
11.00 Location: https://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz [following]
11.00 --2024-02-27 21:03:52--  https://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz
11.00 Resolving ctan.math.washington.edu (ctan.math.washington.edu)... 128.95.224.254
11.03 Connecting to ctan.math.washington.edu (ctan.math.washington.edu)|128.95.224.254|:443... connected.
11.04 ERROR: cannot verify ctan.math.washington.edu's certificate, issued by ‘CN=InCommon RSA Server CA 2,O=Internet2,C=US’:
11.04   Unable to locally verify the issuer's authority.
11.04 To connect to ctan.math.washington.edu insecurely, use `--no-check-certificate'.
11.05 ERROR: Feature "LaTeX Workshop" (ghcr.io/prulloac/devcontainer-features/latex) failed to install!
```

After a bit of digging, it seems that when the `https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz` mirror chooses to redirect to University of Washington, `wget` is unable to validate the certificate.  While I _am_ able to download directly through my browser, I _could_ also repro the certificate issue on the terminal on my Mac:

![Screenshot 2024-02-27 at 11 17 12 AM](https://github.com/prulloac/devcontainer-features/assets/23246594/79bdda18-e325-470e-a204-8b1bb4c0f19a)

Other mirrors (like MIT's) seemed to work well.

Some googling suggested it may be an issue with the certificate needing to be verified via SNI, but after a bit of trial and error I couldn't find a workaround.

Instead, this PR adds a new option `mirror` that lets the user override the region-based automatic redirect that occurs when `wget'ing` https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz .  While not solving the root issue, it does provide the user with a path forward if the resolved mirror does end up dead.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ️ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
