### PR TITLE
latex feature - use mirror option for downloading packages and not just the install script

### DIFF
--- a/src/latex/devcontainer-feature.json
+++ b/src/latex/devcontainer-feature.json
@@ -28,7 +28,7 @@
             "description": "Provide a custom mirror to use for the installation of Tex Live. Omit option to automatically select the mirror closest to you.",
             "proposals": [
                 "https://mirror.ctan.org/systems/texlive/tlnet/",
-                "https://mirrors.mit.edu/CTAN/systems/texlive/"
+                "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet"
             ]
         }
     },

--- a/src/latex/devcontainer-feature.json
+++ b/src/latex/devcontainer-feature.json
@@ -24,11 +24,11 @@
         },
         "mirror": {
             "type": "string",
-            "default": "https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz",
+            "default": "https://mirror.ctan.org/systems/texlive/tlnet/",
             "description": "Provide a custom mirror to use for the installation of Tex Live. Omit option to automatically select the mirror closest to you.",
             "proposals": [
-                "https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz",
-                "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
+                "https://mirror.ctan.org/systems/texlive/tlnet/",
+                "https://mirrors.mit.edu/CTAN/systems/texlive/"
             ]
         }
     },

--- a/src/latex/install.sh
+++ b/src/latex/install.sh
@@ -4,7 +4,7 @@ set -e
 
 SCHEME=${SCHEME:-"basic"}
 PACKAGES=${PACKAGES:-""}
-MIRROR=${MIRROR:-"https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"}
+MIRROR=${MIRROR:-"https://mirror.ctan.org/systems/texlive/tlnet/"}
 
 check_packages() {
 	if ! dpkg -s "$@" >/dev/null 2>&1; then
@@ -19,10 +19,10 @@ check_packages() {
 check_packages ca-certificates perl wget perl-modules libfontconfig1 fontconfig
 
 cd /tmp # working directory of your choice
-wget "$MIRROR" # or curl instead of wget
+wget "${MIRROR}/install-tl-unx.tar.gz" # or curl instead of wget
 zcat < install-tl-unx.tar.gz | tar xf -
 cd $(ls -d */ | grep install-tl-)
-perl ./install-tl --no-interaction --scheme=$SCHEME
+perl ./install-tl --no-interaction --scheme=$SCHEME --location $MIRROR
 
 TEXLIVE_DIR=$(ls -d /usr/local/texlive/* | grep 20)
 TEXLIVE_EXECUTABLES_DIR="$(ls -d $TEXLIVE_DIR/bin/*)"


### PR DESCRIPTION
## 📑 Description
The latex feature has a mirror option, but the mirror only determines where the install script is downloaded from. The install script will itself determine which mirror to use for the packages. This can make the download time for the packages be 20x larger than it has to be if one is unlucky to have a slow mirror nearby, as is the case in Portugal.

This PR uses the "mirror" option to also determine where the packages are downloaded from. It slightly changes the type of URL that is passed to the "mirror" option.