### PR TITLE
Fixing latex test scenario

### DIFF
--- a/src/latex/devcontainer-feature.json
+++ b/src/latex/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "LaTeX Workshop",
     "id": "latex",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Installs Tex Live latex compiler with tlmgr package manager, alongside LaTeX Workshop extension",
     "documentationURL": "https://github.com/prulloac/devcontainer-features/tree/main/src/latex",
     "options": {

--- a/test/latex/scenarios.json
+++ b/test/latex/scenarios.json
@@ -22,7 +22,7 @@
         "features": {
             "latex": {
                 "scheme": "minimal",
-                "mirror": "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
+                "mirror": "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/"
             }
         },
         "remoteUser": "vscode"


### PR DESCRIPTION
This pull request fixes the latex test scenario by updating the mirror URL for texlive to "https://mirrors.mit.edu/CTAN/systems/texlive/tlnet/".